### PR TITLE
Marking as watched in Trakt

### DIFF
--- a/plextraktsync/commands/watch.py
+++ b/plextraktsync/commands/watch.py
@@ -86,6 +86,11 @@ class WatchStateUpdater:
         if not m:
             return
         self.logger.info(f"Activity: {m}: Collected: {m.is_collected}, Watched: [Plex: {m.watched_on_plex}, Trakt: {m.watched_on_trakt}]")
+        
+        if m.watched_on_plex and not m.watched_on_trakt:
+            self.logger.info(f"Marking as watched in Trakt: {m}")
+            m.mark_watched_trakt()
+            self.trakt.flush()
 
         if self.add_collection and not m.is_collected:
             self.logger.info(f"Add to collection: {m}")


### PR DESCRIPTION
Marking as watched in Trakt when watched in Plex but not marked as watched in Trakt yet.
This will help when manually select "Mark as Played" in Plex without playing the video.